### PR TITLE
Fix Molmo2 eager image-pooling attention mask

### DIFF
--- a/src/transformers/models/molmo2/modeling_molmo2.py
+++ b/src/transformers/models/molmo2/modeling_molmo2.py
@@ -206,7 +206,12 @@ class Molmo2GQAAttention(nn.Module):
             value_states = repeat_kv(value_states, self.num_key_value_groups)
             attn_weights = torch.matmul(query_states / math.sqrt(query_states.size(-1)), key_states.transpose(2, 3))
             if attention_mask is not None:
-                attn_weights = attn_weights + attention_mask
+                # The image pooling adapter passes a boolean keep-mask (valid patches); exclude the
+                # invalid ones with -inf to match the SDPA path. A float mask is already additive.
+                if attention_mask.dtype == torch.bool:
+                    attn_weights = attn_weights.masked_fill(~attention_mask, torch.finfo(attn_weights.dtype).min)
+                else:
+                    attn_weights = attn_weights + attention_mask
 
             attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
             attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=self.training)

--- a/src/transformers/models/molmo2/modular_molmo2.py
+++ b/src/transformers/models/molmo2/modular_molmo2.py
@@ -907,7 +907,12 @@ class Molmo2GQAAttention(nn.Module):
             value_states = repeat_kv(value_states, self.num_key_value_groups)
             attn_weights = torch.matmul(query_states / math.sqrt(query_states.size(-1)), key_states.transpose(2, 3))
             if attention_mask is not None:
-                attn_weights = attn_weights + attention_mask
+                # The image pooling adapter passes a boolean keep-mask (valid patches); exclude the
+                # invalid ones with -inf to match the SDPA path. A float mask is already additive.
+                if attention_mask.dtype == torch.bool:
+                    attn_weights = attn_weights.masked_fill(~attention_mask, torch.finfo(attn_weights.dtype).min)
+                else:
+                    attn_weights = attn_weights + attention_mask
 
             attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
             attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=self.training)


### PR DESCRIPTION
## What

`Molmo2GQAAttention` is reused for the vision adapter's `image_pooling_2d`, which passes a **boolean** keep-mask of valid patches. The **eager** path added that boolean mask directly to the attention logits:

```python
attn_weights = attn_weights + attention_mask   # bool -> +1.0 on valid, +0.0 on invalid
```

That only *shifts* the logits, so it is a no-op under softmax for fully-valid pooling groups, and it **fails to exclude invalid patches** for partial groups at image edges. The **SDPA** path already excludes them correctly (`F.scaled_dot_product_attention` treats a boolean mask as keep/`-inf`), so eager and SDPA disagreed for partial pooling groups.

This converts a boolean mask to an additive `-inf` exclusion in the eager path so it matches SDPA; float masks remain additive as before.

```python
if attention_mask is not None:
    if attention_mask.dtype == torch.bool:
        attn_weights = attn_weights.masked_fill(~attention_mask, torch.finfo(attn_weights.dtype).min)
    else:
        attn_weights = attn_weights + attention_mask
```

Edited in `modular_molmo2.py` and regenerated into `modeling_molmo2.py`.

## Why / how found

A layer-by-layer parity check of the port against the original `allenai/Molmo2-8B` (identical inputs, fp32) showed the **pooled** image features diverging ~2.6% in eager mode while being **bit-exact in SDPA**. Splitting the vision pipeline (`ViT→pool` input bit-identical, `pooled` divergent) localized it to the pooling attention, and the divergence was concentrated in partial pooling groups at image boundaries — consistent with the boolean-mask-as-additive bug above.

## Impact / scope

- Only affects **eager** attention for the image pooling adapter; **SDPA (the default) was already correct**, so this aligns eager with SDPA.
- The original checkpoint's remote code has the same eager/SDPA inconsistency (its eager path ignores the pooling mask), so this is a low-priority correctness/robustness alignment, not a regression.
- The vision self-attention and text decoder pass `attention_mask=None` / float masks respectively, so their behavior is unchanged.

## Tests

- fp32 + SDPA parity of the full model (vision backbone, pooling, projection, all text-decoder layers, final logits) against the original is bit-exact (`0.000`).
- Eager pooling divergence (partial groups) is removed by this change.

AI assistance was used to investigate and prepare this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z1uph57N8WrnxSL69bYL4)_